### PR TITLE
docs: fix GitHub links

### DIFF
--- a/apps/docs/stories/introduction.mdx
+++ b/apps/docs/stories/introduction.mdx
@@ -110,10 +110,10 @@ L'utilisation du DSFR est soumise à certaines règles que nous rappelons ici :
 
 ## Support
 
-Si vous rencontrez un problème n'hésitez pas à poster une issue ([https://github.com/sneko/dsfr-connect/issues]()). Ou si vous souhaitez échanger concernant le librairie vous pouvez aussi utiliser la section "Support" en haut de page afin d'ouvrir un livechat.
+Si vous rencontrez un problème n'hésitez pas à poster une issue ([https://github.com/sneko/dsfr-connect/issues](https://github.com/sneko/dsfr-connect/issues)). Ou si vous souhaitez échanger concernant le librairie vous pouvez aussi utiliser la section "Support" en haut de page afin d'ouvrir un livechat.
 
 _Le support sur cette librairie est bénévole, on fera de notre mieux pour vous assister._
 
 ## Contributions
 
-Le code source et les indications pour contribuer sont disponibles sur [https://github.com/sneko/dsfr-connect]().
+Le code source et les indications pour contribuer sont disponibles sur [https://github.com/sneko/dsfr-connect](https://github.com/sneko/dsfr-connect).


### PR DESCRIPTION
hello, thanks for this useful effort

this PR fix some broken links in the intro doc